### PR TITLE
Fixed bug in lognorm.

### DIFF
--- a/baobab/distributions/distributions.py
+++ b/baobab/distributions/distributions.py
@@ -230,7 +230,7 @@ def _lognorm_cdf(bound,mu,sigma):
     return 0.5*erf((np.log(bound)-mu)/(np.sqrt(2)*sigma))
 
 @numba.njit
-def eval_lognormal_logpdf_approx(eval_at, mu, sigma, lower=-np.inf, upper=np.inf):
+def eval_lognormal_logpdf_approx(eval_at, mu, sigma, lower=0, upper=np.inf):
     """Evaluate the normal pdf, optionally truncated without -np.inf
 
     See `sample_normal` for parameter definitions.
@@ -240,6 +240,10 @@ def eval_lognormal_logpdf_approx(eval_at, mu, sigma, lower=-np.inf, upper=np.inf
     norm = -np.log(sigma) - np.log(eval_at) - np.log(2*np.pi)/2
     eval_unnormed_logpdf = -np.square(np.log(eval_at)-mu)/(2*sigma**2)
     eval_unnormed_logpdf += norm
+
+    # Stop cdf from crashing if lower bound is below 0
+    if lower<0:
+        lower=0
 
     accept_norm = _lognorm_cdf(upper,mu,sigma) - _lognorm_cdf(lower,mu,sigma)
     eval_normed_logpdf = eval_unnormed_logpdf - np.log(accept_norm)

--- a/baobab/tests/test_distributions/test_distributions.py
+++ b/baobab/tests/test_distributions/test_distributions.py
@@ -106,6 +106,11 @@ class TestDistributions(unittest.TestCase):
         # assert greater because of the accept_norm
         np.testing.assert_array_less(lpdf-1000,lpdf_approx)
 
+        # Test that the default values work
+        eval_at = np.linspace(-10,10,100)
+        lpdf_approx = bb_dist.eval_normal_logpdf_approx(eval_at,mu,sigma)
+        lpdf = bb_dist.eval_normal_logpdf(eval_at,mu,sigma)
+
     def test_eval_lognormal_logpdf_approx(self):
         # For a specific mu, sigma, upper, and lower, test that the log pdf
         # approximation gives the correct values inside the bounds, and then
@@ -136,6 +141,17 @@ class TestDistributions(unittest.TestCase):
         np.testing.assert_array_less(lpdf_approx, lpdf)
         # assert greater because of the accept_norm
         np.testing.assert_array_less(lpdf-1000,lpdf_approx)
+
+        # Check that without bounds the function behaves as expected.
+        lpdf_approx = bb_dist.eval_lognormal_logpdf_approx(eval_at,mu,sigma)
+        lpdf = bb_dist.eval_lognormal_logpdf(eval_at,mu,sigma)
+        np.testing.assert_almost_equal(lpdf_approx, lpdf, precision)
+
+        # Check that the function doesn't fail if the lower is set to -np.inf
+        lpdf_approx = bb_dist.eval_lognormal_logpdf_approx(eval_at,mu,sigma,lower=-np.inf)
+        lpdf = bb_dist.eval_lognormal_logpdf(eval_at,mu,sigma)
+        np.testing.assert_almost_equal(lpdf_approx, lpdf, precision)
+
 
     def test_eval_beta_logpdf_approx(self):
         # For a specific parameters est that the log pdf
@@ -224,6 +240,10 @@ class TestDistributions(unittest.TestCase):
         precision = 5
         np.testing.assert_almost_equal(lpdf_approx, lpdf, precision)
 
+        eval_at = np.linspace(-1.5,1.5,100)
+        lpdf_approx = bb_dist.eval_generalized_normal_logpdf_approx(eval_at,mu,alpha,p)
+        lpdf = bb_dist.eval_generalized_normal_logpdf(eval_at,mu,alpha,p)
+        np.testing.assert_almost_equal(lpdf_approx, lpdf, precision)
 
 if __name__ == '__main__':
     unittest.main()

--- a/demo/Visualize_DiagonalBNNPrior.ipynb
+++ b/demo/Visualize_DiagonalBNNPrior.ipynb
@@ -567,7 +567,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (baobab)",
+   "display_name": "Python3 (baobab)",
    "language": "python",
    "name": "baobab"
   },
@@ -581,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/demo/Visualize_EmpiricalBNNPrior.ipynb
+++ b/demo/Visualize_EmpiricalBNNPrior.ipynb
@@ -588,7 +588,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (baobab)",
+   "display_name": "Python3 (baobab)",
    "language": "python",
    "name": "baobab"
   },
@@ -602,7 +602,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If lower bound is less than 0, it will now set it to 0 for the calculation. 